### PR TITLE
Metadata Functionality & CBT Saving

### DIFF
--- a/file-comic-book-archive/file-comic-book-archive.py
+++ b/file-comic-book-archive/file-comic-book-archive.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import io
 
 # GIMP Plug-in for the Comic Book Archive File Format
 
@@ -23,11 +24,6 @@ from gi.repository import Gio
 
 import os, sys, tarfile, tempfile, zipfile
 import xml.etree.ElementTree as ET
-
-#Function that loads the thumbnail of the CBZ
-#TODO: Code is very similar to loading the first image in the CBZ,
-#Could we reduce the code duplication by making a new function that
-#both call?
 def thumbnail_cbz(procedure, file, thumb_size, args, data):
     tempdir = tempfile.mkdtemp('gimp-plugin-comic-book-archive')
     cbaffFile = zipfile.ZipFile(file.peek_path())
@@ -166,20 +162,26 @@ def load_image(procedure, run_mode, file, metadata, flags, config, data, compres
         GObject.Value(Gimp.Image, img)
     ]), flags
 
+#Wrapper function that passes the Zipfile object to save_image()
 def save_cbz(procedure, run_mode, image, n_drawables, drawables, file, metadata, config, data):
-    def write_file_str(zfile, fname, data):
-        #zi.external_attr = int("100644", 8) << 16
-        zfile.writestr(fname, data)
-
     Gimp.progress_init("Exporting Comic Book Archive (cbz) image")
     tempdir = tempfile.mkdtemp('gimp-plugin-file-cbz')
     cbaffFile = zipfile.ZipFile(file.peek_path() + '.tmpsave', 'w', compression=zipfile.ZIP_STORED)
+    return save_image(procedure, run_mode, image, n_drawables, drawables, file, metadata, config, data, tempdir, cbaffFile)
 
-    #GUI Code
+#Wrapper function that passes the Tarfile object to save_image()
+def save_cbt(procedure, run_mode, image, n_drawables, drawables, file, metadata, config, data):
+    Gimp.progress_init("Exporting Comic Book Archive (cbt) image")
+    tempdir = tempfile.mkdtemp('gimp-plugin-file-cbt')
+    cbaffFile = tarfile.open(file.peek_path() + '.tmpsave', 'w')
+    return save_image(procedure, run_mode, image, n_drawables, drawables, file, metadata, config, data, tempdir, cbaffFile)
+
+#Function that actually saves the Comic Book Archive file
+def save_image(procedure, run_mode, image, n_drawables, drawables, file, metadata, config, data, tempdir, cbaffFile):
+    #GUI code
     if run_mode == Gimp.RunMode.INTERACTIVE:
         GimpUi.init('python-fu-file-cbz-save')
 
-        #Search for this in the repository and see what else you can do
         dialog = GimpUi.ProcedureDialog(procedure=procedure, config=config)
         dialog.fill(None)
         if not dialog.run():
@@ -188,17 +190,24 @@ def save_cbz(procedure, run_mode, image, n_drawables, drawables, file, metadata,
         else:
             dialog.destroy()
 
-    #Create an xml file and add the user input from the GUI to it
-    xml_image = ET.Element('image')
-    xml_image.set('title', config.get_property('title'))
-    xml_image.set('series', config.get_property('series'))
-    xml_image.set('genre', config.get_property('genre'))
-    xml_image.set('year', config.get_property('year'))
-    xml_image.set('month', config.get_property('month'))
-    xml_image.set('day', config.get_property('day'))
-    xml_image.set('tags', config.get_property('tags'))
-    xml = ET.tostring(xml_image, encoding='UTF-8')
-    write_file_str(cbaffFile, 'metadata.xml', xml)
+        # Save metadata only if the checkbox is checked
+    if config.get_property('save-metadata'):
+        # Create an xml file and add the user input from the GUI to it
+        xml_image = ET.Element('image')
+        xml_image.set('title', config.get_property('title'))
+        xml_image.set('series', config.get_property('series'))
+        xml_image.set('genre', config.get_property('genre'))
+        xml_image.set('year', config.get_property('year'))
+        xml_image.set('month', config.get_property('month'))
+        xml_image.set('day', config.get_property('day'))
+        xml_image.set('tags', config.get_property('tags'))
+        xml = ET.tostring(xml_image, encoding='UTF-8')
+        if(isinstance(cbaffFile, zipfile.ZipFile)):
+            cbaffFile.writestr('metadata.xml', xml)
+        elif(isinstance(cbaffFile, tarfile.TarFile)):
+            tarinfo = tarfile.TarInfo('metadata.xml')
+            tarinfo.size = len(xml)
+            cbaffFile.addfile(tarinfo, io.BytesIO(xml))
 
     def store_layer(image, drawable, path):
         tmp = os.path.join(tempdir, 'tmp.jpeg')
@@ -211,7 +220,10 @@ def save_cbz(procedure, run_mode, image, n_drawables, drawables, file, metadata,
         pdb_config.set_property('file', Gio.File.new_for_path(tmp))
         pdb_proc.run(pdb_config)
         if (os.path.exists(tmp)):
-            cbaffFile.write(tmp, path)
+            if (isinstance(cbaffFile, zipfile.ZipFile)):
+                cbaffFile.write(tmp, path)
+            elif (isinstance(cbaffFile, tarfile.TarFile)):
+                cbaffFile.add(tmp, path)
             os.remove(tmp)
         else:
             print("Error removing ", tmp)
@@ -263,15 +275,15 @@ class FileComicBookArchive(Gimp.PlugIn):
                  "",
                  GObject.ParamFlags.READWRITE),
         "month": (str,
-                 ("Month"),
-                 ("Book Month"),
-                 "",
-                 GObject.ParamFlags.READWRITE),
+                  ("Month"),
+                  ("Book Month"),
+                  "",
+                  GObject.ParamFlags.READWRITE),
         "day": (str,
-                 ("Day"),
-                 ("Book Day"),
-                 "",
-                 GObject.ParamFlags.READWRITE),
+                ("Day"),
+                ("Book Day"),
+                "",
+                GObject.ParamFlags.READWRITE),
         "tags": (str,
                  ("Tags"),
                  ("Book Tags"),
@@ -287,7 +299,8 @@ class FileComicBookArchive(Gimp.PlugIn):
         return ['file-cbz-thumb',
                 'file-cbz-load',
                 'file-cbt-load',
-                'file-cbz-save']
+                'file-cbz-save',
+                'file-cbt-save'] #save query created
 
     def do_create_procedure(self, name):
         if name == 'file-cbz-load':
@@ -322,6 +335,26 @@ class FileComicBookArchive(Gimp.PlugIn):
                                         name)
             procedure.set_menu_label('CBZ')
             procedure.set_extensions("cbz");
+
+            #Adding parameters for GUI
+            procedure.add_argument_from_property(self, "save-metadata")
+            procedure.add_argument_from_property(self, "title")
+            procedure.add_argument_from_property(self, "series")
+            procedure.add_argument_from_property(self, "genre")
+            procedure.add_argument_from_property(self, "year")
+            procedure.add_argument_from_property(self, "month")
+            procedure.add_argument_from_property(self, "day")
+            procedure.add_argument_from_property(self, "tags")
+        elif name == 'file-cbt-save':
+            procedure = Gimp.SaveProcedure.new(self, name,
+                                               Gimp.PDBProcType.PLUGIN,
+                                               False, save_cbt, None)
+            procedure.set_image_types("*");
+            procedure.set_documentation('save a Comic Book Archive (.cbt) file',
+                                        'save a Comic Book Archive (.cbt) file',
+                                        name)
+            procedure.set_menu_label('CBT')
+            procedure.set_extensions("cbt");
 
             #Adding parameters for GUI
             procedure.add_argument_from_property(self, "save-metadata")


### PR DESCRIPTION
Based on testing, the latest push to the metadata branch successfully:
-Saves CBT images (using a wrapper function and general save function to avoid repeated code)
-Saves CBZ images (using a wrapper function and general save function to avoid repeated code)
-Allows users to enter metadata and saves in an XML format for both CBZ and CBT files
-On the reverse, also successfully reloaded both the CBZ and CBT image.
